### PR TITLE
Properly eat key press events from WebKit

### DIFF
--- a/include/selain/tab.hpp
+++ b/include/selain/tab.hpp
@@ -60,6 +60,11 @@ namespace selain
       return m_command_entry;
     }
 
+    inline Mode get_mode() const
+    {
+      return m_mode;
+    }
+
     void set_mode(Mode mode);
 
     Glib::ustring get_uri() const;
@@ -81,7 +86,6 @@ namespace selain
   private:
     void on_show();
     bool on_command_entry_key_press(::GdkEventKey* event);
-    bool on_web_view_key_press(::GdkEventKey* event);
     void on_command_received();
 
   private:

--- a/src/keyboard.cpp
+++ b/src/keyboard.cpp
@@ -33,8 +33,8 @@ namespace selain
   static const int keypress_timeout = 2;
   static std::shared_ptr<keyboard::Mapping> top_mapping;
 
-  static bool key_event_normal_mode(Tab*, ::GdkEventKey*);
-  static bool key_event_insert_mode(Tab*, ::GdkEventKey*);
+  static ::gboolean key_event_normal_mode(Tab*, ::GdkEventKey*);
+  static ::gboolean key_event_insert_mode(Tab*, ::GdkEventKey*);
   static void add_mapping(const std::u32string&, const keyboard::Binding&);
 
   static void bind_mode_command(Tab*);
@@ -101,25 +101,25 @@ namespace selain
       add_mapping(U"n", bind_search_next);
       add_mapping(U"N", bind_search_prev);
     }
-  }
 
-  bool
-  Tab::on_web_view_key_press(GdkEventKey* event)
-  {
-    switch (m_mode)
+    ::gboolean
+    on_tab_key_press(::WebKitWebView*, ::GdkEventKey* event, Tab* tab)
     {
-      case Mode::NORMAL:
-        return key_event_normal_mode(this, event);
+      switch (tab->get_mode())
+      {
+        case Mode::NORMAL:
+          return key_event_normal_mode(tab, event);
 
-      case Mode::INSERT:
-        return key_event_insert_mode(this, event);
+        case Mode::INSERT:
+          return key_event_insert_mode(tab, event);
 
-      default:
-        return GDK_EVENT_PROPAGATE;
+        default:
+          return FALSE;
+      }
     }
   }
 
-  static bool
+  static ::gboolean
   key_event_normal_mode(Tab* tab, ::GdkEventKey* event)
   {
     static std::shared_ptr<keyboard::Mapping> last_mapping;
@@ -151,13 +151,13 @@ namespace selain
       entry = last_mapping->control_mapping.find(event->keyval);
       if (entry == std::end(last_mapping->control_mapping))
       {
-        return GDK_EVENT_STOP;
+        return TRUE;
       }
     } else {
       entry = last_mapping->mapping.find(event->keyval);
       if (entry == std::end(last_mapping->mapping))
       {
-        return GDK_EVENT_STOP;
+        return TRUE;
       }
     }
 
@@ -171,20 +171,20 @@ namespace selain
       last_mapping = entry->second;
     }
 
-    return GDK_EVENT_STOP;
+    return TRUE;
   }
 
-  static bool
+  static ::gboolean
   key_event_insert_mode(Tab* tab, ::GdkEventKey* event)
   {
     if (event->keyval == GDK_KEY_Escape)
     {
       tab->set_mode(Mode::NORMAL);
 
-      return GDK_EVENT_STOP;
+      return TRUE;
     }
 
-    return GDK_EVENT_PROPAGATE;
+    return FALSE;
   }
 
   static void

--- a/src/tab.cpp
+++ b/src/tab.cpp
@@ -50,6 +50,14 @@ namespace selain
     ::gpointer
   );
 
+  namespace keyboard
+  {
+    /**
+     * GTK signal callback used for key press events inside web view of a tab.
+     */
+    ::gboolean on_tab_key_press(::WebKitWebView*, ::GdkEventKey*, Tab*);
+  }
+
   Tab::Tab()
     : Gtk::Box(Gtk::ORIENTATION_VERTICAL)
     , m_mode(Mode::NORMAL)
@@ -65,10 +73,6 @@ namespace selain
     m_command_entry.signal_activate().connect(sigc::mem_fun(
       this,
       &Tab::on_command_received
-    ));
-    m_web_view_widget->signal_key_press_event().connect(sigc::mem_fun(
-      this,
-      &Tab::on_web_view_key_press
     ));
 
     ::g_signal_connect(
@@ -87,6 +91,12 @@ namespace selain
       G_OBJECT(m_web_view),
       "mouse-target-changed",
       G_CALLBACK(on_mouse_target_changed),
+      static_cast<::gpointer>(this)
+    );
+    ::g_signal_connect(
+      G_OBJECT(m_web_view),
+      "key-press-event",
+      G_CALLBACK(keyboard::on_tab_key_press),
       static_cast<::gpointer>(this)
     );
 


### PR DESCRIPTION
Instead of using signals of WebKit GTK component wrapped in Gtk::Widget, use the GTK signal directly with the WebKit component itself. This allows us to properly stop key events when the browser is in normal mode.

Fixes: #1, #3