### PR TITLE
Add placeholder for favicons

### DIFF
--- a/include/selain/main-window.hpp
+++ b/include/selain/main-window.hpp
@@ -124,8 +124,6 @@ namespace selain
     void next_tab();
     void prev_tab();
 
-    void set_tab_title(Tab* tab, const Glib::ustring& title);
-
     void add_notification(
       const Glib::ustring& text,
       NotificationType type = NotificationType::INFO,

--- a/include/selain/tab.hpp
+++ b/include/selain/tab.hpp
@@ -59,6 +59,22 @@ namespace selain
      */
     const MainWindow* get_main_window() const;
 
+    /**
+     * Returns the GTK widget used as label for the tab.
+     */
+    inline Gtk::Widget& get_tab_label()
+    {
+      return m_tab_label;
+    }
+
+    /**
+     * Returns the GTK widget used as label for the tab.
+     */
+    inline const Gtk::Widget& get_tab_label() const
+    {
+      return m_tab_label;
+    }
+
     Glib::ustring get_uri() const;
     void load_uri(const Glib::ustring& uri);
     void reload(bool bypass_cache = false);
@@ -76,6 +92,8 @@ namespace selain
 
     void grab_focus();
 
+    void set_title(const Glib::ustring& title);
+
     const Glib::ustring& get_status() const;
     void set_status(const Glib::ustring& status, bool permanent = false);
 
@@ -90,6 +108,9 @@ namespace selain
     }
 
   private:
+    Gtk::Box m_tab_label;
+    Gtk::Image m_tab_label_icon;
+    Gtk::Label m_tab_label_text;
     ::WebKitWebView* m_web_view;
     Glib::RefPtr<Gtk::Widget> m_web_view_widget;
     Glib::ustring m_status;

--- a/src/main-window.cpp
+++ b/src/main-window.cpp
@@ -129,7 +129,7 @@ namespace selain
   {
     const auto tab = Glib::RefPtr<Tab>(new Tab());
 
-    m_notebook.append_page(*tab.get(), "Untitled");
+    m_notebook.append_page(*tab.get(), tab->get_tab_label());
     tab->signal_status_changed().connect(sigc::mem_fun(
       this,
       &MainWindow::on_tab_status_change
@@ -191,21 +191,6 @@ namespace selain
   MainWindow::prev_tab()
   {
     m_notebook.prev_page();
-  }
-
-  void
-  MainWindow::set_tab_title(Tab* tab, const Glib::ustring& title)
-  {
-    const auto index = m_notebook.page_num(*tab);
-
-    if (index < 0)
-    {
-      return;
-    }
-    m_notebook.set_tab_label_text(
-      *tab,
-      title.length() > 20 ? title.substr(0, 19) + U'\u2026' : title
-    );
   }
 
   void


### PR DESCRIPTION
Use custom component for tab labels in the tab component of the main window, which has place for favicons, even though they are not used yet.