### PR TITLE
Split more things into separate classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ ADD_EXECUTABLE(
   src/mode.cpp
   src/status-bar.cpp
   src/tab.cpp
+  src/tab-label.cpp
   src/theme.cpp
   src/utils.cpp
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ PKG_CHECK_MODULES(WEBKITGTK webkit2gtk-4.0 REQUIRED)
 ADD_EXECUTABLE(
   selain
   src/command.cpp
+  src/command-entry.cpp
   src/keyboard.cpp
   src/main.cpp
   src/main-window.cpp

--- a/include/selain/command-entry.hpp
+++ b/include/selain/command-entry.hpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2019, Rauli Laine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SELAIN_COMMAND_ENTRY_HPP_GUARD
+#define SELAIN_COMMAND_ENTRY_HPP_GUARD
+
+#include <gtkmm.h>
+
+namespace selain
+{
+  class CommandEntry : public Gtk::Bin
+  {
+  public:
+    using signal_command_received_type = sigc::signal<
+      void,
+      const Glib::ustring&
+    >;
+
+    explicit CommandEntry();
+
+    inline Glib::ustring get_text() const
+    {
+      return m_entry.get_text();
+    }
+
+    inline void set_text(const Glib::ustring& text)
+    {
+      m_entry.set_text(text);
+    }
+
+    void grab_focus();
+
+    inline signal_command_received_type& signal_command_received()
+    {
+      return m_signal_command_received;
+    }
+
+  private:
+    void on_activate();
+
+  private:
+    Gtk::Entry m_entry;
+    signal_command_received_type m_signal_command_received;
+  };
+}
+
+#endif /* !SELAIN_COMMAND_ENTRY_HPP_GUARD */

--- a/include/selain/main-window.hpp
+++ b/include/selain/main-window.hpp
@@ -31,6 +31,7 @@
 
 #include <gtkmm.h>
 
+#include <selain/command-entry.hpp>
 #include <selain/notification.hpp>
 #include <selain/status-bar.hpp>
 #include <selain/tab.hpp>
@@ -77,7 +78,7 @@ namespace selain
     /**
      * Returns the text boxed where commands are being typed.
      */
-    inline Gtk::Entry& get_command_entry()
+    inline CommandEntry& get_command_entry()
     {
       return m_command_entry;
     }
@@ -85,7 +86,7 @@ namespace selain
     /**
      * Returns the text boxed where commands are being typed.
      */
-    inline const Gtk::Entry& get_command_entry() const
+    inline const CommandEntry& get_command_entry() const
     {
       return m_command_entry;
     }
@@ -132,7 +133,7 @@ namespace selain
 
   private:
     bool on_command_entry_key_press(::GdkEventKey* event);
-    void on_command_entry_activate();
+    void on_command_received(const Glib::ustring& command);
     void on_tab_status_change(Tab* tab, const Glib::ustring& status);
     void on_tab_switch(Gtk::Widget* widget, ::guint page_number);
     void on_notification_timeout();
@@ -142,7 +143,7 @@ namespace selain
     Gtk::Box m_box;
     Gtk::Notebook m_notebook;
     StatusBar m_status_bar;
-    Gtk::Entry m_command_entry;
+    CommandEntry m_command_entry;
     std::queue<Notification> m_notification_queue;
     std::mutex m_notification_queue_mutex;
   };

--- a/include/selain/tab-label.hpp
+++ b/include/selain/tab-label.hpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2019, Rauli Laine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SELAIN_TAB_LABEL_HPP_GUARD
+#define SELAIN_TAB_LABEL_HPP_GUARD
+
+#include <gtkmm.h>
+
+namespace selain
+{
+  class TabLabel : public Gtk::Box
+  {
+  public:
+    using signal_clicked_type = Glib::SignalProxy<void>;
+
+    explicit TabLabel();
+
+    void set_text(const Glib::ustring& text);
+
+    inline signal_clicked_type signal_close_button_clicked()
+    {
+      return m_close_button.signal_clicked();
+    }
+
+  private:
+    Gtk::Image m_icon;
+    Gtk::Label m_text;
+    Gtk::Button m_close_button;
+  };
+}
+
+#endif /* !SELAIN_TAB_LABEL_HPP_GUARD */

--- a/include/selain/tab-label.hpp
+++ b/include/selain/tab-label.hpp
@@ -39,6 +39,8 @@ namespace selain
 
     void set_text(const Glib::ustring& text);
 
+    void set_icon(const Glib::RefPtr<Gdk::Pixbuf>& icon);
+
     inline signal_clicked_type signal_close_button_clicked()
     {
       return m_close_button.signal_clicked();

--- a/include/selain/tab.hpp
+++ b/include/selain/tab.hpp
@@ -26,7 +26,8 @@
 #ifndef SELAIN_TAB_HPP_GUARD
 #define SELAIN_TAB_HPP_GUARD
 
-#include <gtkmm.h>
+#include <selain/tab-label.hpp>
+
 #include <webkit2/webkit2.h>
 
 namespace selain
@@ -62,7 +63,7 @@ namespace selain
     /**
      * Returns the GTK widget used as label for the tab.
      */
-    inline Gtk::Widget& get_tab_label()
+    inline TabLabel& get_tab_label()
     {
       return m_tab_label;
     }
@@ -70,7 +71,7 @@ namespace selain
     /**
      * Returns the GTK widget used as label for the tab.
      */
-    inline const Gtk::Widget& get_tab_label() const
+    inline const TabLabel& get_tab_label() const
     {
       return m_tab_label;
     }
@@ -92,8 +93,6 @@ namespace selain
 
     void grab_focus();
 
-    void set_title(const Glib::ustring& title);
-
     const Glib::ustring& get_status() const;
     void set_status(const Glib::ustring& status, bool permanent = false);
 
@@ -108,9 +107,10 @@ namespace selain
     }
 
   private:
-    Gtk::Box m_tab_label;
-    Gtk::Image m_tab_label_icon;
-    Gtk::Label m_tab_label_text;
+    void on_close_button_clicked();
+
+  private:
+    TabLabel m_tab_label;
     ::WebKitWebView* m_web_view;
     Glib::RefPtr<Gtk::Widget> m_web_view_widget;
     Glib::ustring m_status;

--- a/src/command-entry.cpp
+++ b/src/command-entry.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2019, Rauli Laine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <selain/command-entry.hpp>
+#include <selain/theme.hpp>
+#include <selain/utils.hpp>
+
+namespace selain
+{
+  CommandEntry::CommandEntry()
+  {
+    m_entry.override_font(utils::get_monospace_font());
+    m_entry.get_style_context()->add_provider(
+      theme::get_command_entry_style_provider(),
+      1000
+    );
+
+    m_entry.signal_activate().connect(sigc::mem_fun(
+      this,
+      &CommandEntry::on_activate
+    ));
+
+    add(m_entry);
+    show_all();
+  }
+
+  void
+  CommandEntry::grab_focus()
+  {
+    m_entry.grab_focus_without_selecting();
+    m_entry.set_position(m_entry.get_text().length());
+  }
+
+  void
+  CommandEntry::on_activate()
+  {
+    const auto text = m_entry.get_text();
+
+    m_entry.set_text(Glib::ustring());
+    m_signal_command_received.emit(text);
+  }
+}

--- a/src/main-window.cpp
+++ b/src/main-window.cpp
@@ -25,7 +25,6 @@
  */
 #include <selain/main-window.hpp>
 #include <selain/theme.hpp>
-#include <selain/utils.hpp>
 
 namespace selain
 {
@@ -54,17 +53,12 @@ namespace selain
       this,
       &MainWindow::on_command_entry_key_press
     ));
-    m_command_entry.signal_activate().connect(sigc::mem_fun(
+    m_command_entry.signal_command_received().connect(sigc::mem_fun(
       this,
-      &MainWindow::on_command_entry_activate
+      &MainWindow::on_command_received
     ));
 
     m_box.override_background_color(theme::window_background);
-    m_command_entry.override_font(utils::get_monospace_font());
-    m_command_entry.get_style_context()->add_provider(
-      theme::get_command_entry_style_provider(),
-      1000
-    );
 
     show_all();
     maximize();
@@ -79,8 +73,7 @@ namespace selain
     switch (m_mode = mode)
     {
       case Mode::COMMAND:
-        m_command_entry.grab_focus_without_selecting();
-        m_command_entry.set_position(m_command_entry.get_text().length());
+        m_command_entry.grab_focus();
         break;
 
       default:
@@ -232,10 +225,8 @@ namespace selain
   }
 
   void
-  MainWindow::on_command_entry_activate()
+  MainWindow::on_command_received(const Glib::ustring& command)
   {
-    const auto command = m_command_entry.get_text();
-
     set_mode(Mode::NORMAL);
     if (const auto tab = get_current_tab())
     {

--- a/src/tab-label.cpp
+++ b/src/tab-label.cpp
@@ -53,4 +53,15 @@ namespace selain
 
     m_text.set_text(length > 20 ? text.substr(0, 19) + U'\u2026' : text);
   }
+
+  void
+  TabLabel::set_icon(const Glib::RefPtr<Gdk::Pixbuf>& icon)
+  {
+    if (icon)
+    {
+      m_icon.set(icon);
+    } else {
+      m_icon.set_from_icon_name("gtk-file", Gtk::ICON_SIZE_BUTTON);
+    }
+  }
 }

--- a/src/tab-label.cpp
+++ b/src/tab-label.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2019, Rauli Laine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <selain/tab-label.hpp>
+
+namespace selain
+{
+  TabLabel::TabLabel()
+    : Gtk::Box(Gtk::ORIENTATION_HORIZONTAL)
+    , m_text("Untitled")
+  {
+    m_icon.set_from_icon_name("gtk-file", Gtk::ICON_SIZE_BUTTON);
+
+    m_close_button.set_relief(Gtk::RELIEF_NONE);
+    m_close_button.set_focus_on_click(false);
+    m_close_button.set_image_from_icon_name(
+      "gtk-close",
+      Gtk::ICON_SIZE_BUTTON
+    );
+
+    pack_start(m_icon, Gtk::PACK_SHRINK);
+    pack_start(m_text);
+    pack_start(m_close_button, Gtk::PACK_SHRINK);
+    show_all();
+  }
+
+  void
+  TabLabel::set_text(const Glib::ustring& text)
+  {
+    const auto length = text.length();
+
+    m_text.set_text(length > 20 ? text.substr(0, 19) + U'\u2026' : text);
+  }
+}

--- a/src/tab-label.cpp
+++ b/src/tab-label.cpp
@@ -31,12 +31,12 @@ namespace selain
     : Gtk::Box(Gtk::ORIENTATION_HORIZONTAL)
     , m_text("Untitled")
   {
-    m_icon.set_from_icon_name("gtk-file", Gtk::ICON_SIZE_BUTTON);
+    m_icon.set_from_icon_name("text-x-generic", Gtk::ICON_SIZE_BUTTON);
 
     m_close_button.set_relief(Gtk::RELIEF_NONE);
     m_close_button.set_focus_on_click(false);
     m_close_button.set_image_from_icon_name(
-      "gtk-close",
+      "window-close",
       Gtk::ICON_SIZE_BUTTON
     );
 
@@ -61,7 +61,7 @@ namespace selain
     {
       m_icon.set(icon);
     } else {
-      m_icon.set_from_icon_name("gtk-file", Gtk::ICON_SIZE_BUTTON);
+      m_icon.set_from_icon_name("text-x-generic", Gtk::ICON_SIZE_BUTTON);
     }
   }
 }

--- a/src/tab.cpp
+++ b/src/tab.cpp
@@ -236,10 +236,7 @@ namespace selain
 
     if (window && window->get_mode() == Mode::COMMAND)
     {
-      auto& command_entry = window->get_command_entry();
-
-      command_entry.grab_focus_without_selecting();
-      command_entry.set_position(command_entry.get_text().length());
+      window->get_command_entry().grab_focus();
     } else {
       m_web_view_widget->grab_focus();
     }

--- a/src/tab.cpp
+++ b/src/tab.cpp
@@ -25,7 +25,6 @@
  */
 #include <selain/main-window.hpp>
 #include <selain/theme.hpp>
-#include <selain/utils.hpp>
 #include <selain/version.hpp>
 
 namespace selain
@@ -58,11 +57,13 @@ namespace selain
   }
 
   Tab::Tab()
-    : m_tab_label(Gtk::ORIENTATION_HORIZONTAL)
-    , m_tab_label_text("Untitled")
-    , m_web_view(WEBKIT_WEB_VIEW(::webkit_web_view_new()))
+    : m_web_view(WEBKIT_WEB_VIEW(::webkit_web_view_new()))
     , m_web_view_widget(Glib::wrap(GTK_WIDGET(m_web_view)))
   {
+    m_tab_label.signal_close_button_clicked().connect(sigc::mem_fun(
+      this,
+      &Tab::on_close_button_clicked
+    ));
     ::g_signal_connect(
       G_OBJECT(m_web_view),
       "load-changed",
@@ -87,11 +88,6 @@ namespace selain
       G_CALLBACK(keyboard::on_tab_key_press),
       static_cast<::gpointer>(this)
     );
-
-    m_tab_label_icon.set_from_icon_name("gtk-file", Gtk::IconSize(16));
-    m_tab_label.pack_start(m_tab_label_icon, Gtk::PACK_SHRINK);
-    m_tab_label.pack_start(m_tab_label_text);
-    m_tab_label.show_all();
 
     add(*m_web_view_widget.get());
 
@@ -242,16 +238,6 @@ namespace selain
     }
   }
 
-  void
-  Tab::set_title(const Glib::ustring& title)
-  {
-    const auto length = title.length();
-
-    m_tab_label_text.set_text(
-      length > 20 ? title.substr(0, 19) + U'\u2026' : title
-    );
-  }
-
   const Glib::ustring&
   Tab::get_status() const
   {
@@ -279,6 +265,15 @@ namespace selain
     }
   }
 
+  void
+  Tab::on_close_button_clicked()
+  {
+    if (const auto window = get_main_window())
+    {
+      window->close_tab(this);
+    }
+  }
+
   static void
   set_webkit_settings(::WebKitSettings* settings)
   {
@@ -299,7 +294,7 @@ namespace selain
     switch (load_event)
     {
       case WEBKIT_LOAD_STARTED:
-        tab->set_title("Loading\xe2\x80\xa6");
+        tab->get_tab_label().set_text("Loading\xe2\x80\xa6");
         if (auto uri = ::webkit_web_view_get_uri(web_view))
         {
           tab->set_status(uri, true);
@@ -308,7 +303,7 @@ namespace selain
         break;
 
       case WEBKIT_LOAD_REDIRECTED:
-        tab->set_title("Redirecting\xe2\x80\xa6");
+        tab->get_tab_label().set_text("Redirecting\xe2\x80\xa6");
         if (auto uri = ::webkit_web_view_get_uri(web_view))
         {
           tab->set_status(Glib::ustring("Redirecting to ") + uri + U'\u2026');
@@ -326,7 +321,7 @@ namespace selain
       {
         const auto title = ::webkit_web_view_get_title(web_view);
 
-        tab->set_title(title && *title ? title : "Untitled");
+        tab->get_tab_label().set_text(title && *title ? title : "Untitled");
         tab->set_status(Glib::ustring());
         break;
       }


### PR DESCRIPTION
For maintainability, split various UI components into their own classes. Also set the tab title by listening for title change notifications from the WebKit component, and introduce support for favicons.

Fixes #4