### PR TITLE
Add crude hit-a-hint implementation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{cpp,hpp,yml}]
+[*.{cpp,hpp,js,yml}]
 indent_style = space
 indent_size = 2
 max_line_length = 79

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ ADD_EXECUTABLE(
   selain
   src/command.cpp
   src/command-entry.cpp
+  src/hint-context.cpp
   src/keyboard.cpp
   src/main.cpp
   src/main-window.cpp

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -4,6 +4,7 @@ Selain currently supports following commands:
 
 |Command    |Shortcut|                                       |
 |-----------|--------|---------------------------------------|
+|`:hint`    |`:h`    |Switches to hint mode.                 |
 |`:insert`  |`:i`    |Switches to insert mode.               |
 |`:open`    |`:o`    |Opens URI given as argument.           |
 |`:open-tab`|`:ot`   |Opens URI given as argument in new tab.|

--- a/doc/keyboard.md
+++ b/doc/keyboard.md
@@ -25,6 +25,7 @@ all keyboard shortcuts are hardcoded and cannot be customized. (Yet.)
 
 |Key|                                     |
 |---|-------------------------------------|
+|`f`|Open link in current tab.            |
 |`k`|Scroll up.                           |
 |`j`|Scroll down.                         |
 |`h`|Scroll left.                         |

--- a/include/selain/hint-context.hpp
+++ b/include/selain/hint-context.hpp
@@ -23,30 +23,34 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef SELAIN_MODE_HPP_GUARD
-#define SELAIN_MODE_HPP_GUARD
+#ifndef SELAIN_HINT_CONTEXT_HPP_GUARD
+#define SELAIN_HINT_CONTEXT_HPP_GUARD
+
+#include <glibmm.h>
+#include <webkit2/webkit2.h>
 
 namespace selain
 {
-  /**
-   * Enumeration of different modes.
-   */
-  enum class Mode
-  {
-    /** Normal mode where Vi key bindings are accepted. */
-    NORMAL,
-    /** Insert mode where Vi key bindings are disabled. */
-    INSERT,
-    /** Command line mode. */
-    COMMAND,
-    /** Hint mode where user can click elements with keyboard shortcuts. */
-    HINT,
-  };
+  class Tab;
 
-  /**
-   * Returns name of the given editing mode as text.
-   */
-  const char* get_mode_text(Mode mode);
+  class HintContext : public Glib::Object
+  {
+  public:
+    static Glib::RefPtr<HintContext> create();
+
+    void install(Tab* tab);
+    void uninstall(Tab* tab);
+
+    void add_digit(Tab* tab, int digit);
+    void remove_digit(Tab* tab);
+    void activate_current_match(Tab* tab);
+
+  private:
+    explicit HintContext();
+
+  private:
+    Glib::ustring m_sequence;
+  };
 }
 
-#endif /* !SELAIN_MODE_HPP_GUARD */
+#endif /* !SELAIN_HINT_CONTEXT_HPP_GUARD */

--- a/include/selain/tab.hpp
+++ b/include/selain/tab.hpp
@@ -26,9 +26,8 @@
 #ifndef SELAIN_TAB_HPP_GUARD
 #define SELAIN_TAB_HPP_GUARD
 
+#include <selain/hint-context.hpp>
 #include <selain/tab-label.hpp>
-
-#include <webkit2/webkit2.h>
 
 namespace selain
 {
@@ -47,6 +46,18 @@ namespace selain
     >;
 
     explicit Tab();
+
+    inline Glib::RefPtr<HintContext>& get_hint_context()
+    {
+      return m_hint_context;
+    }
+
+    inline Glib::RefPtr<const HintContext> get_hint_context() const
+    {
+      return m_hint_context;
+    }
+
+    void set_hint_context(const Glib::RefPtr<HintContext>& hint_context);
 
     /**
      * Returns pointer to the main window where this tab is being displayed, or
@@ -82,7 +93,12 @@ namespace selain
     void stop_loading();
 
     void execute_command(const Glib::ustring& command);
-    void execute_script(const Glib::ustring& script);
+    void execute_script(
+      const Glib::ustring& script,
+      ::GCancellable* cancellable = nullptr,
+      ::GAsyncReadyCallback callback = nullptr,
+      void* user_data = nullptr
+    );
 
     void go_back();
     void go_forward();
@@ -110,6 +126,7 @@ namespace selain
     void on_close_button_clicked();
 
   private:
+    Glib::RefPtr<HintContext> m_hint_context;
     TabLabel m_tab_label;
     ::WebKitWebView* m_web_view;
     Glib::RefPtr<Gtk::Widget> m_web_view_widget;

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -35,6 +35,15 @@ namespace selain
   using command_mapping = std::unordered_map<std::string, command_callback>;
 
   static void
+  cmd_hint_mode(Tab* tab, const Glib::ustring&)
+  {
+    if (const auto window = tab->get_main_window())
+    {
+      window->set_mode(Mode::HINT);
+    }
+  }
+
+  static void
   cmd_insert_mode(Tab* tab, const Glib::ustring&)
   {
     if (const auto window = tab->get_main_window())
@@ -111,6 +120,8 @@ namespace selain
 
   static const command_mapping commands =
   {
+    { "h", cmd_hint_mode },
+    { "hint", cmd_hint_mode },
     { "i", cmd_insert_mode },
     { "insert", cmd_insert_mode },
     { "o", cmd_open },

--- a/src/hint-context.cpp
+++ b/src/hint-context.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2019, Rauli Laine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <selain/main-window.hpp>
+
+#define SELAIN_JS_STRINGIFY(source) #source
+
+namespace selain
+{
+  static Glib::ustring hint_mode_source_code =
+  #include "./hint-mode.js"
+  ;
+
+  Glib::RefPtr<HintContext>
+  HintContext::create()
+  {
+    return Glib::RefPtr<HintContext>(new HintContext());
+  }
+
+  HintContext::HintContext() {}
+
+  void
+  HintContext::install(Tab* tab)
+  {
+    tab->execute_script(hint_mode_source_code);
+  }
+
+  void
+  HintContext::uninstall(Tab* tab)
+  {
+    tab->execute_script("window.SelainHintMode.uninstall();");
+  }
+
+  static void
+  add_digit_callback(::GObject* web_view_object,
+                     ::GAsyncResult* result,
+                     ::gpointer tab_data)
+  {
+    const auto web_view = WEBKIT_WEB_VIEW(web_view_object);
+    const auto tab = static_cast<Tab*>(tab_data);
+    ::GError* error = nullptr;
+    const auto js_result = ::webkit_web_view_run_javascript_finish(
+      web_view,
+      result,
+      &error
+    );
+    ::JSCValue* value;
+
+    if (!js_result)
+    {
+      ::g_warning("Error running JavaScript: %s", error->message);
+      ::g_error_free(error);
+      return;
+    }
+    value = ::webkit_javascript_result_get_js_value(js_result);
+    if (::jsc_value_is_string(value))
+    {
+      auto str_value = ::jsc_value_to_string(value);
+      auto exception = ::jsc_context_get_exception(
+        ::jsc_value_get_context(value)
+      );
+
+      if (exception)
+      {
+        g_warning(
+          "Error running JavaScript: %s",
+          ::jsc_exception_get_message(exception)
+        );
+      }
+      else if (!::g_strcmp0(str_value, "mode::normal"))
+      {
+        if (const auto window = tab->get_main_window())
+        {
+          window->set_mode(Mode::NORMAL);
+        }
+      }
+      else if (!::g_strcmp0(str_value, "mode::insert"))
+      {
+        if (const auto window = tab->get_main_window())
+        {
+          window->set_mode(Mode::INSERT);
+        }
+      }
+      ::g_free(str_value);
+    } else {
+      ::g_warning("Unexpected return value from hint mode.");
+    }
+    ::webkit_javascript_result_unref(js_result);
+  }
+
+  void
+  HintContext::add_digit(Tab* tab, int digit)
+  {
+    if (digit < 0 || digit > 9)
+    {
+      return;
+    }
+    tab->execute_script(
+      Glib::ustring::compose("window.SelainHintMode.addDigit(%1);", digit),
+      nullptr,
+      add_digit_callback,
+      static_cast<void*>(tab)
+    );
+  }
+
+  void
+  HintContext::remove_digit(Tab* tab)
+  {
+    tab->execute_script("window.SelainHintMode.removeDigit();");
+  }
+
+  void
+  HintContext::activate_current_match(Tab* tab)
+  {
+    tab->execute_script(
+      "window.SelainHintMode.activateCurrentMatch();",
+      nullptr,
+      add_digit_callback,
+      static_cast<void*>(tab)
+    );
+  }
+}

--- a/src/hint-mode.js
+++ b/src/hint-mode.js
@@ -1,0 +1,262 @@
+SELAIN_JS_STRINGIFY((() => {
+  const original = window.SelainHintMode;
+  const queryExpression = '//*[@onclick or @onmouseover or @onmousedown or ' +
+    '@onmouseup or @oncommand or @href] | //input[not(@type="hidden")] | ' +
+    '//a[href] | //area | //textarea | //button | //select';
+  const maxAllowedHints = 500;
+  const hints = [];
+  let hintContainer = null;
+  let currentSequence = 0;
+
+  const install = () => {
+    const topWindow = window;
+    const topWindowHeight = topWindow.innerHeight;
+    const topWindowWidth = topWindow.innerWidth;
+    let hintCount = 0;
+
+    const drawHintsToWindow = (win, offsetX, offsetY) => {
+      const doc = win.document;
+      const winHeight = win.height;
+      const winWidth = win.width;
+
+      // Bounds
+      const minX = offsetX < 0 ? -offsetX : 0;
+      const minY = offsetY < 0 ? -offsetY : 0;
+      const maxX = (
+        offsetX + winWidth > topWindowWidth
+          ? topWindowWidth - offsetX
+          : topWindowWidth
+      );
+      const maxY = (
+        offsetY + winHeight > topWindowHeight
+          ? topWindowHeight - offsetY
+          : topWindowHeight
+      );
+
+      const { scrollX, scrollY } = win;
+
+      hintContainer = doc.createElement('div');
+
+      const result = doc.evaluate(
+        queryExpression,
+        doc,
+        () => 'http://www.w3.org/1999/xhtml',
+        XPathResult.ORDERED_NODE_SNAPSHOT_TYPE,
+        null
+      );
+
+      const hintSpan = doc.createElement('span');
+      hintSpan.style.zIndex = '100000';
+      hintSpan.style.position = 'absolute';
+      hintSpan.style.padding = '0.2em';
+      hintSpan.style.borderColor = 'rgba(0, 0, 0, 0.4)';
+      hintSpan.style.borderWidth = '0.15em';
+      hintSpan.style.border = '';
+      hintSpan.style.backgroundColor = '#ffd76e';
+      hintSpan.style.color = '#000000';
+      hintSpan.style.fontFamily = 'monospace';
+      hintSpan.style.fontSize = '1em';
+      hintSpan.style.lineHeight = '1';
+      hintSpan.style.fontWeight = 'bold';
+      hintSpan.style.whiteSpace = 'nowrap';
+      hintSpan.style.textShadow = 'none';
+
+      for (let i = 0; i < result.snapshotLength; ++i) {
+        if (hintCount >= maxAllowedHints) {
+          break;
+        }
+
+        const element = result.snapshotItem(i);
+        const rectangle = element.getBoundingClientRect();
+
+        if (!rectangle ||
+            rectangle.left > maxX ||
+            rectangle.right < minX ||
+            rectangle.top > maxY ||
+            rectangle.bottom < minY) {
+          continue;
+        }
+
+        const style = topWindow.getComputedStyle(element, '');
+        if (style.display === 'none' || style.visibility !== 'visible') {
+          continue;
+        }
+
+        const leftPos = Math.max(rectangle.left + scrollX, scrollX);
+        const topPos = Math.max(rectangle.top + scrollY, scrollY);
+
+        let hintNumber = hintCount;
+        if (element.nodeName.toLowerCase() === 'a') {
+          for (let j = 0; j < hints.length; ++j) {
+            const existingHint = hints[j];
+
+            if (existingHint.element.nodeName.toLowerCase() !== 'a') {
+              continue;
+            }
+            if (existingHint.element.href === element.href) {
+              hintNumber = existingHint.number - 1;
+              break;
+            }
+          }
+        }
+
+        const hint = hintSpan.cloneNode(false);
+        hint.style.left = `${leftPos}px`;
+        hint.style.top = `${topPos}px`;
+        hint.innerText = `${hintNumber + 1}`;
+        hintContainer.appendChild(hint);
+
+        if (hintNumber === hintCount) {
+          ++hintCount;
+        } else {
+          hintNumber = -2;
+        }
+
+        hints.push({
+          element,
+          number: hintNumber + 1,
+          span: hint,
+        });
+      }
+
+      doc.documentElement.appendChild(hintContainer);
+
+      // Also go through the frames contained in the document.
+      ['frame', 'iframe'].forEach((tagName) => {
+        const frames = doc.getElementsByTagName(tagName);
+
+        for (let i = 0; i < frames.length; ++i) {
+          const element = frames[i];
+          const rectangle = element.getBoundingClientRect();
+
+          if (!element.contentWindow ||
+              !rectangle ||
+              rectangle.left > maxX ||
+              rectangle.right < minX ||
+              rectangle.top > maxY ||
+              rectangle.bottom < minY) {
+            continue;
+          }
+          drawHintsToWindow(
+            element.contentWindow,
+            offsetX + rectangle.left,
+            offsetY + rectangle.top
+          );
+        }
+      });
+    };
+
+    drawHintsToWindow(topWindow, 0, 0);
+  };
+
+  const uninstall = () => {
+    hints
+      .filter((hint) => typeof hint.element !== 'undefined')
+      .forEach((hint) => {
+        hint.span.parentNode.removeChild(hint.span);
+      });
+    hints.length = 0;
+    if (hintContainer) {
+      hintContainer.parentNode.removeChild(hintContainer);
+      hintContainer = null;
+    }
+    window.SelainHintMode = original;
+  };
+
+  const getNearestMatches = () => hints.filter(
+    (hint) => `${hint.number}`.startsWith(`${currentSequence}`)
+  );
+
+  const activateHint = (hint) => {
+    if (!hint || typeof hint.element === 'undefined') {
+      return 'ignore';
+    }
+
+    const { element } = hint;
+    const tagName = element.nodeName.toLowerCase();
+
+    uninstall();
+
+    if (['input', 'select', 'textarea'].indexOf(tagName) >= 0) {
+      element.focus();
+
+      return 'mode::insert';
+    } else if (['frame', 'iframe'].indexOf(tagName) >= 0) {
+      element.focus();
+    } else {
+      // TODO: Add support for the "open in new tab" -feature.
+      element.click();
+    }
+
+    return 'mode::normal';
+  };
+
+  const addDigit = (digit) => {
+    if (typeof digit !== 'number' || digit < 0 || digit > 9) {
+      return;
+    }
+
+    currentSequence = (currentSequence * 10) + digit;
+
+    hints
+      .filter((hint) => hint.span.style.visiblity !== 'hidden')
+      .filter((hint) => !`${hint.number}`.startsWith(`${currentSequence}`))
+      .forEach((hint) => {
+        hint.span.style.visibility = 'hidden';
+      });
+
+    const nearestMatches = getNearestMatches();
+
+    if (nearestMatches.length === 1) {
+      return activateHint(nearestMatches[0]);
+    }
+
+    return 'ignore';
+  };
+
+  const removeDigit = () => {
+    if (currentSequence <= 0) {
+      return;
+    }
+
+    currentSequence = Math.floor(currentSequence / 10);
+
+    let hintsToBeShown = hints
+      .filter((hint) => hint.span.style.visibility === 'hidden');
+
+    if (currentSequence > 0) {
+      hintsToBeShown = hintsToBeShown.filter(
+        (hint) => `${hint.number}`.startsWith(`${currentSequence}`)
+      );
+    }
+
+    hintsToBeShown.forEach((hint) => {
+      hint.span.style.visibility = 'visible';
+    });
+  };
+
+  const activateCurrentMatch = () => {
+    if (currentSequence <= 0) {
+      return 'ignore';
+    }
+
+    const match = hints.find(
+      (hint) => `${hint.number}` === `${currentSequence}`
+    );
+
+    if (match) {
+      return activateHint(match);
+    }
+
+    return 'ignore';
+  };
+
+  install();
+
+  window.SelainHintMode = {
+    activateCurrentMatch,
+    addDigit,
+    removeDigit,
+    uninstall
+  };
+})();)

--- a/src/main-window.cpp
+++ b/src/main-window.cpp
@@ -69,6 +69,16 @@ namespace selain
   void
   MainWindow::set_mode(Mode mode)
   {
+    const auto tab = get_current_tab();
+
+    if (m_mode == Mode::HINT && tab)
+    {
+      if (auto& context = tab->get_hint_context())
+      {
+        context->uninstall(tab);
+        context.reset();
+      }
+    }
     m_status_bar.set_mode(mode);
     switch (m_mode = mode)
     {
@@ -76,9 +86,15 @@ namespace selain
         m_command_entry.grab_focus();
         break;
 
+      case Mode::HINT:
+        if (tab)
+        {
+          tab->set_hint_context(HintContext::create());
+        }
+
       default:
         m_command_entry.set_text(Glib::ustring());
-        if (const auto tab = get_current_tab())
+        if (tab)
         {
           tab->grab_focus();
         }

--- a/src/mode.cpp
+++ b/src/mode.cpp
@@ -40,6 +40,9 @@ namespace selain
 
       case Mode::COMMAND:
         return "COMMAND";
+
+      case Mode::HINT:
+        return "HINT";
     }
 
     return "UNKNOWN";

--- a/src/tab.cpp
+++ b/src/tab.cpp
@@ -124,6 +124,20 @@ namespace selain
     set_webkit_context(::webkit_web_view_get_context(m_web_view));
   }
 
+  void
+  Tab::set_hint_context(const Glib::RefPtr<HintContext>& hint_context)
+  {
+    if (m_hint_context)
+    {
+      m_hint_context->uninstall(this);
+      m_hint_context.reset();
+    }
+    if ((m_hint_context = hint_context))
+    {
+      m_hint_context->install(this);
+    }
+  }
+
   MainWindow*
   Tab::get_main_window()
   {
@@ -188,14 +202,17 @@ namespace selain
   }
 
   void
-  Tab::execute_script(const Glib::ustring& script)
+  Tab::execute_script(const Glib::ustring& script,
+                      ::GCancellable* cancellable,
+                      ::GAsyncReadyCallback callback,
+                      void* user_data)
   {
     ::webkit_web_view_run_javascript(
       m_web_view,
       script.c_str(),
-      nullptr,
-      nullptr,
-      nullptr
+      cancellable,
+      callback,
+      static_cast<::gpointer>(user_data)
     );
   }
 


### PR DESCRIPTION
Hit-a-hint is a must have feature for a browser that is used mainly with a keyboard. Implementing such feature with only C++ is impossible with current WebKit API, due to DOM access being disabled, so I had to go into my hacky mode and implement such thing with JavaScript included in the C++ source code, which is then injected into the document.

It's still missing ability to open links into new tabs and has kinda crude UI, which could be improved later.

Implements #2