### PR TITLE
Add persistent storage for cookies, cache and favicons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ ADD_EXECUTABLE(
   src/tab-label.cpp
   src/theme.cpp
   src/utils.cpp
+  src/web-context.cpp
 )
 
 TARGET_COMPILE_FEATURES(

--- a/src/tab.cpp
+++ b/src/tab.cpp
@@ -29,8 +29,9 @@
 
 namespace selain
 {
+  ::WebKitWebContext* create_web_context();
+
   static void set_webkit_settings(::WebKitSettings*);
-  static void set_webkit_context(::WebKitWebContext*);
   static void on_load_changed(
     ::WebKitWebView*,
     ::WebKitLoadEvent,
@@ -68,7 +69,9 @@ namespace selain
   }
 
   Tab::Tab()
-    : m_web_view(WEBKIT_WEB_VIEW(::webkit_web_view_new()))
+    : m_web_view(WEBKIT_WEB_VIEW(::webkit_web_view_new_with_context(
+        create_web_context()
+      )))
     , m_web_view_widget(Glib::wrap(GTK_WIDGET(m_web_view)))
   {
     m_tab_label.signal_close_button_clicked().connect(sigc::mem_fun(
@@ -121,7 +124,6 @@ namespace selain
     );
 
     set_webkit_settings(::webkit_web_view_get_settings(m_web_view));
-    set_webkit_context(::webkit_web_view_get_context(m_web_view));
   }
 
   void
@@ -328,16 +330,6 @@ namespace selain
       "Selain",
       SELAIN_VERSION
     );
-  }
-
-  // TODO: Create shared instance of `WebKitWebContext` during application
-  // startup and use that instead.
-  static void
-  set_webkit_context(::WebKitWebContext* context)
-  {
-    // Enable favicons by setting the favicon database directory to NULL, which
-    // tells WebKit to use the default user cache directory.
-    ::webkit_web_context_set_favicon_database_directory(context, nullptr);
   }
 
   static void

--- a/src/web-context.cpp
+++ b/src/web-context.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2019, Rauli Laine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <selain/main-window.hpp>
+
+namespace selain
+{
+  static inline void
+  free_string(::gchar* str)
+  {
+    if (str)
+    {
+      ::g_free(str);
+    }
+  }
+
+  ::WebKitWebContext*
+  create_web_context()
+  {
+    ::gchar* base_cache_dir = nullptr;
+    ::gchar* base_data_dir = nullptr;
+    ::gchar* disk_cache_dir = nullptr;
+    ::gchar* indexeddb_dir = nullptr;
+    ::gchar* local_storage_dir = nullptr;
+    ::gchar* offline_app_dir = nullptr;
+    ::gchar* websql_dir = nullptr;
+    ::gchar* cookie_file = nullptr;
+    ::gchar* favicon_cache_dir = nullptr;
+    ::WebKitWebContext* context;
+
+    if (const auto user_cache_dir = ::g_get_user_cache_dir())
+    {
+      base_cache_dir = ::g_build_filename(
+        user_cache_dir,
+        "selain",
+        nullptr
+      );
+      base_data_dir = ::g_build_filename(
+        user_cache_dir,
+        "selain",
+        "data",
+        nullptr
+      );
+      disk_cache_dir = ::g_build_filename(
+        user_cache_dir,
+        "selain",
+        "disk",
+        nullptr
+      );
+      indexeddb_dir = ::g_build_filename(
+        user_cache_dir,
+        "selain",
+        "indexeddb",
+        nullptr
+      );
+      local_storage_dir = ::g_build_filename(
+        user_cache_dir,
+        "selain",
+        "local-storage",
+        nullptr
+      );
+      offline_app_dir = ::g_build_filename(
+        user_cache_dir,
+        "selain",
+        "offline-app",
+        nullptr
+      );
+      websql_dir = ::g_build_filename(
+        user_cache_dir,
+        "selain",
+        "websql",
+        nullptr
+      );
+      cookie_file = ::g_build_filename(
+        user_cache_dir,
+        "selain",
+        "cookies.sqlite",
+        nullptr
+      );
+      favicon_cache_dir = ::g_build_filename(
+        user_cache_dir,
+        "selain",
+        "favicons",
+        nullptr
+      );
+    }
+
+    context = ::webkit_web_context_new_with_website_data_manager(
+      ::webkit_website_data_manager_new(
+        "base-cache-directory",
+        base_cache_dir,
+        "base-data-directory",
+        base_data_dir,
+        "disk-cache-directory",
+        disk_cache_dir,
+        "indexeddb-directory",
+        indexeddb_dir,
+        "local-storage-directory",
+        local_storage_dir,
+        "offline-application-cache-directory",
+        offline_app_dir,
+        "websql-directory",
+        websql_dir,
+        nullptr
+      )
+    );
+
+    ::webkit_web_context_set_favicon_database_directory(
+      context,
+      favicon_cache_dir
+    );
+
+    if (cookie_file)
+    {
+      ::webkit_cookie_manager_set_persistent_storage(
+        ::webkit_web_context_get_cookie_manager(context),
+        cookie_file,
+        WEBKIT_COOKIE_PERSISTENT_STORAGE_SQLITE
+      );
+    }
+
+    free_string(base_cache_dir);
+    free_string(base_data_dir);
+    free_string(disk_cache_dir);
+    free_string(indexeddb_dir);
+    free_string(offline_app_dir);
+    free_string(websql_dir);
+    free_string(cookie_file);
+    free_string(favicon_cache_dir);
+
+    return context;
+  }
+}


### PR DESCRIPTION
Instead of having the browser constantly running in incognito mode, introduce persistent storage for cookies, cache, favicons and various other data used by todays Web pages.

Implements #6