### PR TITLE
Wrap WebKit some stuff into classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ ADD_EXECUTABLE(
   src/theme.cpp
   src/utils.cpp
   src/web-context.cpp
+  src/web-settings.cpp
 )
 
 TARGET_COMPILE_FEATURES(

--- a/include/selain/main-window.hpp
+++ b/include/selain/main-window.hpp
@@ -140,6 +140,7 @@ namespace selain
 
   private:
     Glib::RefPtr<WebContext> m_web_context;
+    Glib::RefPtr<WebSettings> m_web_settings;
     Mode m_mode;
     Gtk::Box m_box;
     Gtk::Notebook m_notebook;

--- a/include/selain/main-window.hpp
+++ b/include/selain/main-window.hpp
@@ -139,6 +139,7 @@ namespace selain
     void on_notification_timeout();
 
   private:
+    Glib::RefPtr<WebContext> m_web_context;
     Mode m_mode;
     Gtk::Box m_box;
     Gtk::Notebook m_notebook;

--- a/include/selain/tab.hpp
+++ b/include/selain/tab.hpp
@@ -29,6 +29,7 @@
 #include <selain/hint-context.hpp>
 #include <selain/tab-label.hpp>
 #include <selain/web-context.hpp>
+#include <selain/web-settings.hpp>
 
 namespace selain
 {
@@ -46,7 +47,10 @@ namespace selain
       const Glib::ustring&
     >;
 
-    explicit Tab(const Glib::RefPtr<WebContext>& context);
+    explicit Tab(
+      const Glib::RefPtr<WebContext>& context,
+      const Glib::RefPtr<WebSettings>& settings
+    );
 
     inline Glib::RefPtr<HintContext>& get_hint_context()
     {

--- a/include/selain/tab.hpp
+++ b/include/selain/tab.hpp
@@ -28,6 +28,7 @@
 
 #include <selain/hint-context.hpp>
 #include <selain/tab-label.hpp>
+#include <selain/web-context.hpp>
 
 namespace selain
 {
@@ -45,7 +46,7 @@ namespace selain
       const Glib::ustring&
     >;
 
-    explicit Tab();
+    explicit Tab(const Glib::RefPtr<WebContext>& context);
 
     inline Glib::RefPtr<HintContext>& get_hint_context()
     {

--- a/include/selain/web-context.hpp
+++ b/include/selain/web-context.hpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2019, Rauli Laine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SELAIN_WEB_CONTEXT_HPP_GUARD
+#define SELAIN_WEB_CONTEXT_HPP_GUARD
+
+#include <glibmm.h>
+#include <webkit2/webkit2.h>
+
+namespace selain
+{
+  /**
+   * Wrapper for the WebKitWebContext type.
+   */
+  class WebContext : public Glib::ObjectBase
+  {
+  public:
+    /**
+     * Constructs new web context instance.
+     */
+    static Glib::RefPtr<WebContext> create();
+
+    /**
+     * Creates new web view using the wrapped web context.
+     */
+    ::WebKitWebView* create_web_view();
+
+  private:
+    explicit WebContext();
+
+  private:
+    ::WebKitWebContext* m_context;
+  };
+}
+
+#endif /* !SELAIN_WEB_CONTEXT_HPP_GUARD */

--- a/include/selain/web-settings.hpp
+++ b/include/selain/web-settings.hpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019, Rauli Laine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SELAIN_WEB_SETTINGS_HPP_GUARD
+#define SELAIN_WEB_SETTINGS_HPP_GUARD
+
+#include <glibmm.h>
+#include <webkit2/webkit2.h>
+
+namespace selain
+{
+  /**
+   * Wrapper for the WebKitSettings type.
+   */
+  class WebSettings : public Glib::ObjectBase
+  {
+  public:
+    /**
+     * Constructs new web settings instance.
+     */
+    static Glib::RefPtr<WebSettings> create();
+
+    void install(::WebKitWebView* view);
+
+  private:
+    explicit WebSettings();
+
+  private:
+    ::WebKitSettings* m_settings;
+  };
+}
+
+#endif /* !SELAIN_WEB_SETTINGS_HPP_GUARD */

--- a/src/main-window.cpp
+++ b/src/main-window.cpp
@@ -34,6 +34,7 @@ namespace selain
   MainWindow::MainWindow(const Glib::RefPtr<Gtk::Application>& application)
     : Gtk::ApplicationWindow(application)
     , m_web_context(WebContext::create())
+    , m_web_settings(WebSettings::create())
     , m_mode(Mode::NORMAL)
     , m_box(Gtk::ORIENTATION_VERTICAL)
   {
@@ -137,7 +138,7 @@ namespace selain
   Glib::RefPtr<Tab>
   MainWindow::open_tab(const Glib::ustring& uri, bool focus)
   {
-    const auto tab = Glib::RefPtr<Tab>(new Tab(m_web_context));
+    const auto tab = Glib::RefPtr<Tab>(new Tab(m_web_context, m_web_settings));
 
     m_notebook.append_page(*tab.get(), tab->get_tab_label());
     tab->signal_status_changed().connect(sigc::mem_fun(

--- a/src/main-window.cpp
+++ b/src/main-window.cpp
@@ -33,6 +33,7 @@ namespace selain
 
   MainWindow::MainWindow(const Glib::RefPtr<Gtk::Application>& application)
     : Gtk::ApplicationWindow(application)
+    , m_web_context(WebContext::create())
     , m_mode(Mode::NORMAL)
     , m_box(Gtk::ORIENTATION_VERTICAL)
   {
@@ -136,7 +137,7 @@ namespace selain
   Glib::RefPtr<Tab>
   MainWindow::open_tab(const Glib::ustring& uri, bool focus)
   {
-    const auto tab = Glib::RefPtr<Tab>(new Tab());
+    const auto tab = Glib::RefPtr<Tab>(new Tab(m_web_context));
 
     m_notebook.append_page(*tab.get(), tab->get_tab_label());
     tab->signal_status_changed().connect(sigc::mem_fun(

--- a/src/tab.cpp
+++ b/src/tab.cpp
@@ -29,8 +29,6 @@
 
 namespace selain
 {
-  ::WebKitWebContext* create_web_context();
-
   static void set_webkit_settings(::WebKitSettings*);
   static void on_load_changed(
     ::WebKitWebView*,
@@ -68,10 +66,8 @@ namespace selain
     ::gboolean on_tab_key_press(::WebKitWebView*, ::GdkEventKey*, Tab*);
   }
 
-  Tab::Tab()
-    : m_web_view(WEBKIT_WEB_VIEW(::webkit_web_view_new_with_context(
-        create_web_context()
-      )))
+  Tab::Tab(const Glib::RefPtr<WebContext>& context)
+    : m_web_view(context->create_web_view())
     , m_web_view_widget(Glib::wrap(GTK_WIDGET(m_web_view)))
   {
     m_tab_label.signal_close_button_clicked().connect(sigc::mem_fun(

--- a/src/tab.cpp
+++ b/src/tab.cpp
@@ -25,11 +25,9 @@
  */
 #include <selain/main-window.hpp>
 #include <selain/theme.hpp>
-#include <selain/version.hpp>
 
 namespace selain
 {
-  static void set_webkit_settings(::WebKitSettings*);
   static void on_load_changed(
     ::WebKitWebView*,
     ::WebKitLoadEvent,
@@ -66,7 +64,8 @@ namespace selain
     ::gboolean on_tab_key_press(::WebKitWebView*, ::GdkEventKey*, Tab*);
   }
 
-  Tab::Tab(const Glib::RefPtr<WebContext>& context)
+  Tab::Tab(const Glib::RefPtr<WebContext>& context,
+           const Glib::RefPtr<WebSettings>& settings)
     : m_web_view(context->create_web_view())
     , m_web_view_widget(Glib::wrap(GTK_WIDGET(m_web_view)))
   {
@@ -119,7 +118,7 @@ namespace selain
       theme::window_background.gobj()
     );
 
-    set_webkit_settings(::webkit_web_view_get_settings(m_web_view));
+    settings->install(m_web_view);
   }
 
   void
@@ -311,21 +310,6 @@ namespace selain
     {
       window->close_tab(*this);
     }
-  }
-
-  // TODO: Create shared instance of `WebKitSettings` during application
-  // startup and use that instead.
-  static void
-  set_webkit_settings(::WebKitSettings* settings)
-  {
-    ::webkit_settings_set_enable_java(settings, false);
-    ::webkit_settings_set_enable_plugins(settings, false);
-    ::webkit_settings_set_enable_developer_extras(settings, true);
-    ::webkit_settings_set_user_agent_with_application_details(
-      settings,
-      "Selain",
-      SELAIN_VERSION
-    );
   }
 
   static void

--- a/src/web-context.cpp
+++ b/src/web-context.cpp
@@ -23,10 +23,30 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include <selain/main-window.hpp>
+#include <selain/web-context.hpp>
 
 namespace selain
 {
+  static ::WebKitWebContext* create_web_context();
+
+  Glib::RefPtr<WebContext>
+  WebContext::create()
+  {
+    return Glib::RefPtr<WebContext>(new WebContext());
+  }
+
+  WebContext::WebContext()
+    : m_context(create_web_context())
+  {
+    initialize(G_OBJECT(m_context));
+  }
+
+  ::WebKitWebView*
+  WebContext::create_web_view()
+  {
+    return WEBKIT_WEB_VIEW(::webkit_web_view_new_with_context(m_context));
+  }
+
   static inline void
   free_string(::gchar* str)
   {
@@ -36,7 +56,7 @@ namespace selain
     }
   }
 
-  ::WebKitWebContext*
+  static ::WebKitWebContext*
   create_web_context()
   {
     ::gchar* base_cache_dir = nullptr;

--- a/src/web-settings.cpp
+++ b/src/web-settings.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2019, Rauli Laine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <selain/web-settings.hpp>
+#include <selain/version.hpp>
+
+namespace selain
+{
+  Glib::RefPtr<WebSettings>
+  WebSettings::create()
+  {
+    return Glib::RefPtr<WebSettings>(new WebSettings());
+  }
+
+  WebSettings::WebSettings()
+    : m_settings(::webkit_settings_new())
+  {
+    initialize(G_OBJECT(m_settings));
+
+    ::webkit_settings_set_enable_java(m_settings, false);
+    ::webkit_settings_set_enable_plugins(m_settings, false);
+    ::webkit_settings_set_enable_developer_extras(m_settings, true);
+    ::webkit_settings_set_user_agent_with_application_details(
+      m_settings,
+      "Selain",
+      SELAIN_VERSION
+    );
+  }
+
+  void
+  WebSettings::install(::WebKitWebView* view)
+  {
+    ::webkit_web_view_set_settings(view, m_settings);
+  }
+}


### PR DESCRIPTION
Properly wrap `WebKitWebContext` and `WebKitSettings` objects into a class and use a shared instance for them for all tabs.